### PR TITLE
fix typos, add resizeStyle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ If using the CLI for Metalsmith, metalsmith-convert can be used like any other p
 {
   "plugins": {
     "metalsmith-convert": {
-      "src": "**/*.svn",
+      "src": "**/*.svg",
       "target": "png"
     }
   }
 }
 ```
 
-For metalsmiths JavaScript API, metalsmith-convert can be used like any other plugin, by attaching it to the function invocation chain on the metalscript object.  For example:
+For metalsmiths JavaScript API, metalsmith-convert can be used like any other plugin, by attaching it to the function invocation chain on the metalsmith object.  For example:
 
 ```js
-var copy = require('metalsmith-convert');
+var convert = require('metalsmith-convert');
 require('metalsmith')(__dirname)
   .use(convert({
     src: '**/*.svg',
@@ -55,17 +55,17 @@ require('metalsmith')(__dirname)
 
 ## Options
 
-metalsmith-convert requires a `src` and `target` options.
+metalsmith-convert requires the `src` and `target` options.
 
 - `src` is a globbing pattern that specifies which files to convert
 - `target` is an imagemagick format specifier
 - `extension` the file extension to use for the conversion target (starting with `.`). Set to `"." + target` if not given explicitly.
 - `remove` if set to `true`, don't include the source-file in the build directory.
 - `resize` set to `{width: XXX, height: YYY}` to resize the image; the name will reflect the size (`name_XXX_YYY.ext`) if `nameFormat` is not given.
-- resizeStyle: optional. default: 'aspectfill'. can be 'aspectfit','fill'
-  - aspectfill: keep aspect ratio, get the exact provided size.
-  - aspectfit:  keep aspect ratio, get maximum image that fits inside provided size
-  - fill:       forget aspect ratio, get the exact provided size
+  - `resizeStyle`: optional. default: 'aspectfill'. can be 'aspectfit','fill'. Must be added as a parameter to the `resize` option.
+    - `aspectfill`: keep aspect ratio, get the exact provided size.
+    - `aspectfit`:  keep aspect ratio, get maximum image that fits inside provided size
+    - `fill`:       forget aspect ratio, get the exact provided size
 - `nameFormat` give the format for the names of the converted files, the following placeholders are available
   - `%b` the basename of the source file, e.g. given `source.png`, the value will be `source`
   - `%e` the extension of the target format, including the dot
@@ -86,7 +86,7 @@ It is possible to pass options as array of option-objects to implement multiple 
       {
         "src": "**/*.svg",
         "target": "png",
-        "resize": {width: 640, height: 480},
+        "resize": {width: 640, height: 480, resizeStyle: 'aspectfit'},
         "nameFormat": "%b_thumb_large%e"
       }
     ]


### PR DESCRIPTION
* Fix `.svn` to `.svg`
* Fix require variable from `copy` to `convert`
* Fix indentation level of `resizeStyle` documentation, to make it clearer it's part of the `resize` option
* Add example that uses the resizeStyle option so users don't need to go dig into the tests to find the correct syntax
* A few other minor fixes.