### PR TITLE
Added support for more imagemagick options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ metalsmith-convert requires the `src` and `target` options.
   - `%e` the extension of the target format, including the dot
   - `%x` the width of the resulting image
   - `%y` the height if the resulting image
-  
+
+The plugin also forwards certain options directly to imagemagick-native, these options are `density`, `blur`, `rotate`, `flip`, `strip` and `quality`. See [imagemagick-native docs](https://github.com/mash/node-imagemagick-native#convertoptions-callback) for more info.
+
 It is possible to pass options as array of option-objects to implement multiple rules, e.g. resize to two sizes for different thumbnail sizes:
 ```json
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,12 +31,12 @@ function convert(options) {
     if (util.isArray(options)) {
       options.forEach(function(opts) {
         pass(opts);
-      })
+      });
     } else {
       pass(options);
     }
     return done(ret);
-  }
+  };
 }
 
 function convertFile(file, ext, args, files, results) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,20 @@ function convertFile(file, ext, args, files, results) {
     var currentExt = path.extname(file);
     nameData['%b'] = path.basename(file, currentExt);
 
+    // Pass options to imagemagick-native
+    [
+      'density',
+      'blur',
+      'rotate',
+      'flip',
+      'strip',
+      'quality'
+    ].forEach(function (setting) {
+      if (args.hasOwnProperty(setting)) {
+        convertArgs[setting] = args[setting];
+      }
+    });
+
     if (args.resize) {
       convertArgs['width'] = args.resize.width;
       convertArgs['height'] = args.resize.height;
@@ -86,4 +100,3 @@ function assembleFilename(format, data) {
   }
   return result;
 }
-

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
+    "image-size": "^0.3.5",
     "metalsmith": "^0.7.0",
     "metalsmith-collections": "^0.4.0",
     "mocha": "^1.18.2"

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,8 @@
 var assert = require('assert'),
     metalsmith = require('metalsmith'),
     convert = require('..');
-    fs = require('fs');
+    fs = require('fs'),
+    sizeOf = require('image-size');
 
 function convert_test(options, fn) {
   // build callback can be called multiple times if an error condition occurs
@@ -128,8 +129,13 @@ describe('metalsmith-convert', function() {
         nameFormat: '%b_thumb%e'
     }, function(err, files){
       if (err) return done(err);
-        assert.equal(files['static/images/test_thumb.png'].contents, fs.readFileSync('test/fixtures/simple/expected/test_thumb.png', 'utf8'), 'aspectFit was correctly used');
-        return done();
+        var result = sizeOf(files['static/images/test_thumb.png'].contents);
+
+        sizeOf('test/fixtures/simple/expected/test_thumb.png', function (err, dimensions) {
+          if (err) return done(err);
+          assert.deepEqual(result, dimensions, 'aspectFit was correctly used');
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
Forwards `density`, `blur`, `rotate`, `flip`, `strip` and `quality` directly to imagemagic-native convert options.

I had the need to set a custom quality when converting images, 90% was just too high. While setting up so that the plugin forwarded the quality option I took the liberty of adding a couple of other options as well.

The plugin still defaults to 90% quality and `"strip": true` to not break backwards compatibility.

I also took the time to fix the aspectFit test by comparing image size as opposed to file contents.