### PR TITLE
updating imagemagick-native to 1.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^0.8.1",
-    "imagemagick-native": "elad/node-imagemagick-native.git#travis-4.1",
+    "imagemagick-native": "^1.9.2",
     "minimatch": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey there - I've been getting some weird errors when using `metalsmith-convert` (similar to https://github.com/elad/node-imagemagick-native/issues/17), and I think I've tracked it down to the `imagemagick-native` version. 

Updating the version has worked for me, and local tests have passed. 

Let me know if there's something I should change, or if this isn't something that you'd like to do right now. Thanks!